### PR TITLE
Add setBytes method to DataView

### DIFF
--- a/ext/arraybuffer/dataview.c
+++ b/ext/arraybuffer/dataview.c
@@ -458,8 +458,29 @@ t_dv_setbytes(VALUE self, VALUE index, VALUE bytes) {
     for (unsigned int i = 0; i < length; i++) {
       bb->ptr[idx0 + i] = (unsigned char)str_ptr[i];
     }
+  } else if (RB_TYPE_P(bytes, T_DATA) &&
+    (CLASS_OF(bytes) == cArrayBuffer || CLASS_OF(bytes) == cDataView)) {
+    unsigned int length;
+    const char *src_bytes;
+    if (CLASS_OF(bytes) == cArrayBuffer) {
+      struct LLC_ArrayBuffer *src_bb = (struct LLC_ArrayBuffer*)rb_data_object_get(bytes);
+      length = src_bb->size;
+      src_bytes = (const char*)src_bb->ptr;
+    } else {
+      struct LLC_DataView *src_dv = (struct LLC_DataView*)rb_data_object_get(bytes);
+      struct LLC_ArrayBuffer *src_bb = (struct LLC_ArrayBuffer*)rb_data_object_get(src_dv->bb_obj);
+      length = src_dv->size;
+      src_bytes = (const char*)(src_bb->ptr + (size_t)src_dv->offset);
+      if (src_dv->offset >= src_bb->size)
+        rb_raise(rb_eRuntimeError, "offset exceeds the underlying source buffer size");
+      if (src_dv->offset + length >= src_bb->size)
+        rb_raise(rb_eRuntimeError, "offset + size exceeds the underlying source buffer size");
+    }
+
+    CHECKBOUNDSBB(idx0 + length);
+    memcpy((void*)(bb->ptr + (size_t)idx0), src_bytes, (size_t)length);
   } else {
-    rb_raise(rb_eArgError, "Invalid type");
+    rb_raise(rb_eArgError, "Invalid type: %+"PRIsVALUE, CLASS_OF(bytes));
   }
 
   return self;
@@ -486,6 +507,7 @@ Init_dataview() {
   rb_define_method(cDataView, "setU16", t_dv_setu16, 2);
   rb_define_method(cDataView, "setU24", t_dv_setu24, 2);
   rb_define_method(cDataView, "setU32", t_dv_setu32, 2);
+
   rb_define_method(cDataView, "setBytes", t_dv_setbytes, 2);
 
   rb_define_method(cDataView, "endianess", t_dv_endianess, 0);

--- a/ext/arraybuffer/dataview.c
+++ b/ext/arraybuffer/dataview.c
@@ -446,6 +446,8 @@ t_dv_setbytes(VALUE self, VALUE index, VALUE bytes) {
     CHECKBOUNDSBB(idx0 + length);
 
     for (unsigned int i = 0; i < length; i++) {
+      if (!RB_FIXNUM_P(items[i]))
+        rb_raise(rb_eRuntimeError, "array contains non fixnum value at index %d", i);
       int num = NUM2INT(items[i]);
       ADJUSTBOUNDS(num, 0xFF);
       bb->ptr[idx0 + i] = (unsigned char)num;

--- a/spec/dataview_spec.rb
+++ b/spec/dataview_spec.rb
@@ -210,6 +210,35 @@ describe DataView do
     end
   end
 
+  describe "setBytes" do
+    let(:dv) { described_class.new(buffer, 1) }
+    let(:new_bytes) { [40, 0, 13, 25, 250, 127, 128] }
+    let(:expected_bytes) { [1, 40, 0, 13, 25, 250, 127, 128, 99, 192, 32, 12, 0, 49] }
+
+    context "when argument is an array" do
+      it "sets the bytes" do
+        dv.setBytes(0, new_bytes)
+        expect(buffer.bytes.split('').map(&:ord)).to eq(expected_bytes)
+      end
+    end
+
+    context "when argument is a string" do
+      it "sets the bytes" do
+        dv.setBytes(0, new_bytes.map(&:chr).join)
+        expect(buffer.bytes.split('').map(&:ord)).to eq(expected_bytes)
+      end
+    end
+
+    context "when argument is an utf-8 string" do
+      let(:expected_bytes) { [1, 233, 139, 184, 105, 27, 175, 88, 99, 192, 32, 12, 0, 49] }
+
+      it "sets the bytes" do
+        dv.setBytes(0, "鋸i")
+        expect(buffer.bytes.split('').map(&:ord)).to eq(expected_bytes)
+      end
+    end
+  end
+
   shared_examples "offset out of bounds" do
     context "when offset is greater than the underlying buffer" do
       let(:offset) { 1000 }

--- a/spec/dataview_spec.rb
+++ b/spec/dataview_spec.rb
@@ -239,6 +239,34 @@ describe DataView do
       end
     end
 
+    context "when argument is an ArrayBuffer" do
+      let(:new_bytes_buffer) do
+        ArrayBuffer.new(new_bytes.length).tap do |buf|
+          new_bytes.each_with_index { |val, i| buf[i] = val }
+        end
+      end
+
+      it "sets the bytes" do
+        dv.setBytes(0, new_bytes_buffer)
+        expect(buffer.bytes.split('').map(&:ord)).to eq(expected_bytes)
+      end
+    end
+
+    context "when argument is a DataView" do
+      let(:src_offset) { 130 }
+      let(:new_bytes_buffer) do
+        ArrayBuffer.new(200).tap do |buf|
+          new_bytes.each_with_index { |val, i| buf[i + src_offset] = val }
+        end
+      end
+      let(:new_bytes_view) { DataView.new(new_bytes_buffer, src_offset, new_bytes.length) }
+
+      it "sets the bytes" do
+        dv.setBytes(0, new_bytes_view)
+        expect(buffer.bytes.split('').map(&:ord)).to eq(expected_bytes)
+      end
+    end
+
     context "when argument is an utf-8 string" do
       let(:expected_bytes) { [1, 233, 139, 184, 105, 27, 175, 88, 99, 192, 32, 12, 0, 49] }
 

--- a/spec/dataview_spec.rb
+++ b/spec/dataview_spec.rb
@@ -215,6 +215,16 @@ describe DataView do
     let(:new_bytes) { [40, 0, 13, 25, 250, 127, 128] }
     let(:expected_bytes) { [1, 40, 0, 13, 25, 250, 127, 128, 99, 192, 32, 12, 0, 49] }
 
+    context "with non-zero index" do
+      let(:new_bytes) { [40, 0, 3] }
+      let(:expected_bytes) { [1, 20, 255, 40, 0, 3, 175, 88, 99, 192, 32, 12, 0, 49] }
+
+      it "just works" do
+        dv.setBytes(2, new_bytes)
+        expect(buffer.bytes.split('').map(&:ord)).to eq(expected_bytes)
+      end
+    end
+
     context "when argument is an array" do
       it "sets the bytes" do
         dv.setBytes(0, new_bytes)

--- a/spec/dataview_spec.rb
+++ b/spec/dataview_spec.rb
@@ -215,6 +215,15 @@ describe DataView do
     let(:new_bytes) { [40, 0, 13, 25, 250, 127, 128] }
     let(:expected_bytes) { [1, 40, 0, 13, 25, 250, 127, 128, 99, 192, 32, 12, 0, 49] }
 
+    context "when array contain non numbers" do
+      before { new_bytes[4] = "foo" }
+
+      it "raises an error" do
+        expect { dv.setBytes(0, new_bytes) }.to raise_error(RuntimeError,
+          /array contains non fixnum value at index 4/)
+      end
+    end
+
     context "with non-zero index" do
       let(:new_bytes) { [40, 0, 3] }
       let(:expected_bytes) { [1, 20, 255, 40, 0, 3, 175, 88, 99, 192, 32, 12, 0, 49] }


### PR DESCRIPTION
Allows writing multiple bytes at once.

Open issues before merging:

- [x] Input can be a String. Works for any encoding
- [x] Input can be an array of numbers
- [x] Input can be a DataView or a ArrayBuffer itself
- [x] What if array of numbers has non-numbers?
- [ ] No counterpart in [DataView specification](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView). How to solve this?